### PR TITLE
修复了部分题目中的链接错误

### DIFF
--- a/LeetCode/1001-1010/1006. 笨阶乘（中等）.md
+++ b/LeetCode/1001-1010/1006. 笨阶乘（中等）.md
@@ -220,7 +220,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 

--- a/LeetCode/1011-1020/1011. 在 D 天内送达包裹的能力（中等）.md
+++ b/LeetCode/1011-1020/1011. 在 D 天内送达包裹的能力（中等）.md
@@ -187,7 +187,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 

--- a/LeetCode/1031-1040/1034. 边界着色（中等）.md
+++ b/LeetCode/1031-1040/1034. 边界着色（中等）.md
@@ -168,7 +168,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 

--- a/LeetCode/1031-1040/1035. 不相交的线（中等）.md
+++ b/LeetCode/1031-1040/1035. 不相交的线（中等）.md
@@ -116,7 +116,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 

--- a/LeetCode/1041-1050/1044. 最长重复子串（困难）.md
+++ b/LeetCode/1041-1050/1044. 最长重复子串（困难）.md
@@ -175,7 +175,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 

--- a/LeetCode/1041-1050/1047. 删除字符串中的所有相邻重复项（简单）.md
+++ b/LeetCode/1041-1050/1047. 删除字符串中的所有相邻重复项（简单）.md
@@ -171,7 +171,7 @@ class Solution {
 
 在这个系列文章里面，除了讲解解题思路以外，还会尽可能给出最为简洁的代码。如果涉及通解还会相应的代码模板。
 
-为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode。
+为了方便各位同学能够电脑上进行调试和提交代码，我建立了相关的仓库：https://github.com/SharingSource/LogicStack-LeetCode 。
 
 在仓库地址里，你可以看到系列文章的题解链接、系列文章的相应代码、LeetCode 原题链接和其他优选题解。
 


### PR DESCRIPTION
查看题解时发现部分链接有误，建议使用 `[]()` 的语法添加链接。